### PR TITLE
Fix for yui-compressor issue in mac

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,8 +9,8 @@ if [ "$(which npm)" == "" ]; then
 	ERR=1
 fi 
 
-if [ "$(which yui-compressor)" == "" ]; then
-	perr "!!! yui-compressor is missing. Please install package yui-compressor."; 
+if [ "$(which yui-compressor)" == "" ] && [ "$(which yuicompressor)" == "" ]; then
+	perr "!!! yui-compressor is missing. Please install package yui-compressor or yuicompressor."; 
 	ERR=1
 fi 
 

--- a/juci-compile
+++ b/juci-compile
@@ -16,6 +16,10 @@ done
 
 for file in `find $BIN/www/css/ -name "*.css"`; do 
 	echo "Compiling CSS ${file}.."
-	yui-compressor ${file} > ${file}.out
+	if [ "$(which yui-compressor)" != "" ]; then
+		yui-compressor ${file} > ${file}.out
+	else
+		yuicompressor ${file} > ${file}.out
+	fi
 	mv ${file}.out ${file}
 done


### PR DESCRIPTION
The command “yui-compressor” is not available for OS X it’s equivalent is “yuicompressor”, made modifications that checks for and uses “yuicompressor” when available… 