### PR TITLE
Fix repository URLs

### DIFF
--- a/docs/juci.md.tpl
+++ b/docs/juci.md.tpl
@@ -3,8 +3,8 @@ JUCI
 
 JUCI WebGUI is designed for building modern and dynamic web interfaces for embedded devices. 
 
-* Project git: [http://mkschreder.github.com/juci](http://mkschreder.github.com/juci)
-* Official docs: [http://mkschreder.github.io/juci](http://mkschreder.github.io/juci)
+* Project git: [https://github.com/mkschreder/juci](https://github.com/mkschreder/juci)
+* Official docs: [https://mkschreder.github.io/juci](https://mkschreder.github.io/juci)
 
 Installing 
 ----------


### PR DESCRIPTION
_This looks like an awesome project! Can't wait to see this running on my router._

The two first links are currently identical, but should obviously direct to the GitHub page and the documentation, respectively. This change also makes the URLs use HTTPS (GitHub's default as of today).